### PR TITLE
Hook method to add custom data to JSON event

### DIFF
--- a/json/classic/src/main/java/ch/qos/logback/contrib/json/classic/JsonLayout.java
+++ b/json/classic/src/main/java/ch/qos/logback/contrib/json/classic/JsonLayout.java
@@ -219,7 +219,21 @@ public class JsonLayout extends JsonLayoutBase<ILoggingEvent> {
             }
         }
 
+        addCustomDataToJsonMap(map, event);
         return map;
+    }
+
+    /**
+     * Override to add custom data to the produced JSON from the logging event.
+     * Useful if you e.g. want to include the parameter array as a separate json attribute.
+     *
+     * @param map the map for JSON serialization, populated with data corresponding to the
+     *            configured attributes. Add new entries from the event to this map to have
+     *            them included in the produced JSON.
+     * @param event the logging event to extract data from.
+     */
+    protected void addCustomDataToJsonMap(Map<String, Object> map, ILoggingEvent event) {
+        // Nothing to do in default implementation
     }
 
     public boolean isIncludeLevel() {


### PR DESCRIPTION
There are certain situations where you want to include custom data in the produced JSON event. This may include e.g. the argument array, unformatted message, etc.

Rather than including explicit support for all these situations, this pull request adds a hook method to JsonLayout, enabling you to simply subclass and override the new method and add the fields you need to include in the produced JSON.

An example where this would be useful is described here:
http://stackoverflow.com/questions/22615311/is-there-a-logback-layout-that-creates-json-objects-with-message-parameters-as-a
