### PR TITLE
Initial commit of project Logback Contrib :: Janino Fragment.

### DIFF
--- a/janino-fragment/README.md
+++ b/janino-fragment/README.md
@@ -1,0 +1,28 @@
+# Problem
+
+As stated in the [Logback documentation](http://logback.qos.ch/setup.html)
+conditional processing in configuration files requires the
+[Janino library](http://unkrig.de/w/Janino). When running in an OSGi environment
+(e.g. an Eclipse RCP application) simply placing `commons-compiler.jar` and
+`janino.jar` on your application's class path is not sufficient enough.
+You will get the following exception:
+
+```
+<...>
+12:50:47,754 |-INFO in ch.qos.logback.classic.joran.action.RootLoggerAction - Setting level of ROOT logger to DEBUG
+12:50:47,755 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [stdout] to Logger[ROOT]
+12:50:47,755 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [file] to Logger[ROOT]
+12:50:47,810 |-ERROR in ch.qos.logback.core.joran.conditional.IfAction -
+  Failed to parse condition [property("instance").equals("PRODUCTION_ENV")] org.codehaus.janino.JaninoRuntimeException:
+  Cannot load class 'ch.qos.logback.core.joran.conditional.PropertyWrapperForScripts' through the parent loader
+  at org.codehaus.janino.JaninoRuntimeException
+<...>
+```
+
+# Solution implemented by this project
+
+The `org.codehaus.janino` bundle needs a `Require-Bundle: ch.qos.logback.core`
+directive in it's manifest file in order for the bundle class loader to be
+able to load classes from the `ch.qos.logback.core` bundle. This can be achieved
+by extending the `org.codehaus.janino` bundle via a fragment
+(`ch.qos.logback.contrib.logback-janino-fragment`).

--- a/janino-fragment/pom.xml
+++ b/janino-fragment/pom.xml
@@ -1,0 +1,45 @@
+<!--
+
+    Copyright (C) 2014, The logback-contrib developers. All rights reserved.
+
+    This program and the accompanying materials are dual-licensed under
+    either the terms of the Eclipse Public License v1.0 as published by
+    the Eclipse Foundation
+
+      or (per the licensee's choosing)
+
+    under the terms of the GNU Lesser General Public License version 2.1
+    as published by the Free Software Foundation.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ch.qos.logback.contrib</groupId>
+        <artifactId>logback-contrib-parent</artifactId>
+        <version>0.1.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>logback-janino-fragment</artifactId>
+    <name>Logback Contrib :: Janino Fragment</name>
+    <description>Needed to uses Janino together with logback in an OSGi environment.</description>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <_include>src/main/resources/META-INF/MANIFEST.MF</_include>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/janino-fragment/src/main/resources/META-INF/MANIFEST.MF
+++ b/janino-fragment/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Fragment-Host: org.codehaus.janino
+Require-Bundle: ch.qos.logback.core

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
         <module>jackson</module>
         <module>mongodb</module>
         <module>eclipse</module>
+        <module>janino-fragment</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
New project to enable the use of Janino together with logback in an OSGi environment. For details about this new project please see `README.md` file.

Further notes:

* [Mail on logback-dev mailing list](http://mailman.qos.ch/pipermail/logback-dev/2015-November/010279.html) about this new project.
* The `Bundle-SymbolicName` of the Janino bundle currently has a typo (`org.cohehaus.janino` instead of `org.codehaus.janino`). I have prepared PR aunkrig/janino#2 to fix this.