### PR TITLE
Refactor and add junit tests to classic JsonLayout

### DIFF
--- a/json/access/pom.xml
+++ b/json/access/pom.xml
@@ -44,13 +44,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
         </dependency>

--- a/json/access/src/main/java/ch/qos/logback/contrib/json/access/JsonLayout.java
+++ b/json/access/src/main/java/ch/qos/logback/contrib/json/access/JsonLayout.java
@@ -221,12 +221,6 @@ public class JsonLayout extends JsonLayoutBase<IAccessEvent> {
         return map;
     }
 
-    protected void addMap(String key, boolean field, Map<String, ?> mapValue, Map<String, Object> map) {
-        if (field && mapValue != null && !mapValue.isEmpty()) {
-            map.put(key, mapValue);
-        }
-    }
-
     protected void addRequestTime(long requestTime, Map<String, Object> map) {
         if (this.includeRequestTime && requestTime > 0) {
             final long sec = TimeUnit.MILLISECONDS.toSeconds(requestTime);
@@ -238,25 +232,10 @@ public class JsonLayout extends JsonLayoutBase<IAccessEvent> {
         }
     }
 
-    protected void addTimestamp(String key, boolean field, long timeStamp, Map<String, Object> map) {
-        if(field){
-            String formatted = formatTimestamp(timeStamp);
-            if (formatted != null) {
-                map.put(key, formatted);
-            }
-        }
-    }
-
     protected void addInt(String key, boolean field, int intValue, Map<String, Object> map) {
         if (field) {
             String statusCode = String.valueOf(intValue);
             map.put(key, statusCode);
-        }
-    }
-
-    protected void add(String fieldName, boolean field, String value, Map<String, Object> map) {
-        if (field && value != null) {
-            map.put(fieldName, value);
         }
     }
 

--- a/json/access/src/test/java/ch/qos/logback/contrib/json/access/JsonLayoutTest.java
+++ b/json/access/src/test/java/ch/qos/logback/contrib/json/access/JsonLayoutTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import static ch.qos.logback.contrib.json.access.JsonLayout.REQUESTTIME_ATTR_NAME;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
+import static org.junit.matchers.JUnitMatchers.containsString;
 
 /**
  * Tests the {@link JsonLayout} class
@@ -148,19 +149,19 @@ public class JsonLayoutTest {
         jsonLayout.setContext(context);
         String log = jsonLayout.doLayout(iAccessEvent);
 
-        assertThat(log.contains(String.format("%s=%s", JsonLayout.REMOTEHOST_ATTR_NAME, event.getRemoteHost())), is(true));
-        assertThat(log.contains(String.format("%s=%s", JsonLayout.REMOTEUSER_ATTR_NAME, event.getRemoteUser())), is(true));
-        assertThat(log.contains(String.format("%s=%s", JsonLayout.REMOTEADDR_ATTR_NAME, event.getRemoteAddr())), is(true));
-        assertThat(log.contains(String.format("%s=%s", JsonLayout.METHOD_ATTR_NAME, event.getMethod())), is(true));
+        assertThat(log, containsString(String.format("%s=%s", JsonLayout.REMOTEHOST_ATTR_NAME, event.getRemoteHost())));
+        assertThat(log, containsString(String.format("%s=%s", JsonLayout.REMOTEUSER_ATTR_NAME, event.getRemoteUser())));
+        assertThat(log, containsString(String.format("%s=%s", JsonLayout.REMOTEADDR_ATTR_NAME, event.getRemoteAddr())));
+        assertThat(log, containsString(String.format("%s=%s", JsonLayout.METHOD_ATTR_NAME, event.getMethod())));
         if (event.getRequestHeaderMap().size() == 2) {
             Iterator<Map.Entry<String, String>> iterator = event.getRequestHeaderMap().entrySet().iterator();
             Map.Entry<String, String> firstInMap = iterator.next();
             Map.Entry<String, String> secondInMap = iterator.next();
-            assertThat(log.contains(String.format("%s={%s=%s, %s=%s}", JsonLayout.REQUESTHEADER_ATTR_NAME, firstInMap.getKey(), firstInMap.getValue(), secondInMap.getKey(), secondInMap.getValue())), is(true));
+            assertThat(log, containsString(String.format("%s={%s=%s, %s=%s}", JsonLayout.REQUESTHEADER_ATTR_NAME, firstInMap.getKey(), firstInMap.getValue(), secondInMap.getKey(), secondInMap.getValue())));
         }
-        assertThat(log.contains(String.format("%s=%s", JsonLayout.PROTOCOL_ATTR_NAME, event.getProtocol())), is(true));
-        assertThat(log.contains(String.format("%s=%s", JsonLayout.SERVERNAME_ATTR_NAME, event.getServerName())), is(true));
-        assertThat(log.contains(String.format("%s=%s", JsonLayout.STATUSCODE_ATTR_NAME, event.getStatusCode())), is(true));
+        assertThat(log, containsString(String.format("%s=%s", JsonLayout.PROTOCOL_ATTR_NAME, event.getProtocol())));
+        assertThat(log, containsString(String.format("%s=%s", JsonLayout.SERVERNAME_ATTR_NAME, event.getServerName())));
+        assertThat(log, containsString(String.format("%s=%s", JsonLayout.STATUSCODE_ATTR_NAME, event.getStatusCode())));
     }
 
     @Test
@@ -182,10 +183,10 @@ public class JsonLayoutTest {
         jsonLayout.includeResponseContent = true;
         String log = jsonLayout.doLayout(iAccessEvent);
 
-        assertThat(log.contains(String.format("%s=%s", JsonLayout.CONTENTLENGTH_ATTR_NAME, event.getContentLength())), is(true));
-        assertThat(log.contains(String.format("%s=%s", JsonLayout.REQUESTURL_ATTR_NAME, event.getMethod())), is(true));
-        assertThat(log.contains(String.format("%s=%s", JsonLayout.LOCALPORT_ATTR_NAME, event.getLocalPort())), is(true));
-        assertThat(log.contains(String.format("%s=%s", JsonLayout.RESPONSECONTENT_ATTR_NAME, event.getResponseContent())), is(true));
-        assertThat(log.contains(String.format("%s=%s", JsonLayout.REQUESTCONTENT_ATTR_NAME, event.getRequestContent())), is(true));
+        assertThat(log, containsString(String.format("%s=%s", JsonLayout.CONTENTLENGTH_ATTR_NAME, event.getContentLength())));
+        assertThat(log, containsString(String.format("%s=%s", JsonLayout.REQUESTURL_ATTR_NAME, event.getMethod())));
+        assertThat(log, containsString(String.format("%s=%s", JsonLayout.LOCALPORT_ATTR_NAME, event.getLocalPort())));
+        assertThat(log, containsString(String.format("%s=%s", JsonLayout.RESPONSECONTENT_ATTR_NAME, event.getResponseContent())));
+        assertThat(log, containsString(String.format("%s=%s", JsonLayout.REQUESTCONTENT_ATTR_NAME, event.getRequestContent())));
     }
 }

--- a/json/access/src/test/java/ch/qos/logback/contrib/json/access/JsonLayoutTest.java
+++ b/json/access/src/test/java/ch/qos/logback/contrib/json/access/JsonLayoutTest.java
@@ -27,6 +27,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static ch.qos.logback.contrib.json.access.JsonLayout.REQUESTTIME_ATTR_NAME;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 import static org.junit.matchers.JUnitMatchers.containsString;
@@ -56,10 +58,10 @@ public class JsonLayoutTest {
         jsonLayout.add("key3", true, null, map);
 
         assertThat(map.size(), is(1));
-        assertThat(map.containsKey("key1"), is(true));
+        assertThat(map, hasKey("key1"));
         assertEquals(map.get("key1"), "value1");
-        assertThat(map.containsKey("key2"), is(false));
-        assertThat(map.containsKey("key3"), is(false));
+        assertThat(map, not(hasKey("key2")));
+        assertThat(map, not(hasKey("key3")));
     }
 
     @Test
@@ -71,10 +73,10 @@ public class JsonLayoutTest {
         jsonLayout.addInt("key3", true, -1, map);
 
         assertThat(map.size(), is(2));
-        assertThat(map.containsKey("key1"), is(true));
+        assertThat(map, hasKey("key1"));
         assertEquals(map.get("key1"), "1");
-        assertThat(map.containsKey("key2"), is(false));
-        assertThat(map.containsKey("key3"), is(true));
+        assertThat(map, not(hasKey("key2")));
+        assertThat(map, hasKey("key3"));
         assertEquals(map.get("key3"), "-1");
     }
 
@@ -88,9 +90,9 @@ public class JsonLayoutTest {
         jsonLayout.addTimestamp("key3", true, -1, map);
 
         assertThat(map.size(), is(2));
-        assertThat(map.containsKey("key1"), is(true));
-        assertThat(map.containsKey("key2"), is(false));
-        assertThat(map.containsKey("key3"), is(true));
+        assertThat(map, hasKey("key1"));
+        assertThat(map, not(hasKey("key2")));
+        assertThat(map, hasKey("key3"));
         assertEquals("-1", map.get("key3"));
     }
 
@@ -101,7 +103,7 @@ public class JsonLayoutTest {
         jsonLayout.addRequestTime(10001, map);
 
         assertThat(map.size(), is(1));
-        assertThat(map.containsKey(REQUESTTIME_ATTR_NAME), is(true));
+        assertThat(map, hasKey(REQUESTTIME_ATTR_NAME));
         assertEquals("10.001", map.get(REQUESTTIME_ATTR_NAME));
 
         Map<String, Object> map2 = new LinkedHashMap<String, Object>();

--- a/json/access/src/test/java/ch/qos/logback/contrib/json/access/JsonLayoutTest.java
+++ b/json/access/src/test/java/ch/qos/logback/contrib/json/access/JsonLayoutTest.java
@@ -130,10 +130,10 @@ public class JsonLayoutTest {
         jsonLayout.addMap("key4", false, mapWithArrayValue, map);
 
         assertThat(map.size(), is(2));
-        assertThat(map.containsKey("key1"), is(false));
+        assertThat(map, not(hasKey("key1")));
         assertEquals(mapWithData, map.get("key2"));
         assertEquals(mapWithArrayValue, map.get("key3"));
-        assertThat(map.containsKey("key4"), is(false));
+        assertThat(map, not(hasKey("key4")));
     }
 
 

--- a/json/access/src/test/java/ch/qos/logback/contrib/json/access/JsonLayoutTest.java
+++ b/json/access/src/test/java/ch/qos/logback/contrib/json/access/JsonLayoutTest.java
@@ -40,6 +40,7 @@ public class JsonLayoutTest {
     private AccessContext context = new AccessContext();
 
     private void configure(String file) throws JoranException {
+        context.reset();
         JoranConfigurator jc = new JoranConfigurator();
         jc.setContext(context);
         jc.doConfigure(file);

--- a/json/access/src/test/java/ch/qos/logback/contrib/json/access/JsonLayoutTest.java
+++ b/json/access/src/test/java/ch/qos/logback/contrib/json/access/JsonLayoutTest.java
@@ -29,6 +29,11 @@ import java.util.Map;
 import static ch.qos.logback.contrib.json.access.JsonLayout.REQUESTTIME_ATTR_NAME;
 import static org.junit.Assert.*;
 
+/**
+ * Tests the {@link JsonLayout} class
+ *
+ * @author Espen A. Fossen
+ */
 public class JsonLayoutTest {
 
     private AccessContext context = new AccessContext();

--- a/json/access/src/test/java/ch/qos/logback/contrib/json/access/JsonLayoutTest.java
+++ b/json/access/src/test/java/ch/qos/logback/contrib/json/access/JsonLayoutTest.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static ch.qos.logback.contrib.json.access.JsonLayout.REQUESTTIME_ATTR_NAME;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
 /**
@@ -52,11 +53,11 @@ public class JsonLayoutTest {
         jsonLayout.add("key2", false, "value2", map);
         jsonLayout.add("key3", true, null, map);
 
-        assertTrue(map.size() == 1);
-        assertTrue(map.containsKey("key1"));
+        assertThat(map.size(), is(1));
+        assertThat(map.containsKey("key1"), is(true));
         assertEquals(map.get("key1"), "value1");
-        assertFalse(map.containsKey("key2"));
-        assertFalse(map.containsKey("key3"));
+        assertThat(map.containsKey("key2"), is(false));
+        assertThat(map.containsKey("key3"), is(false));
     }
 
     @Test
@@ -67,11 +68,11 @@ public class JsonLayoutTest {
         jsonLayout.addInt("key2", false, 1, map);
         jsonLayout.addInt("key3", true, -1, map);
 
-        assertTrue(map.size() == 2);
-        assertTrue(map.containsKey("key1"));
+        assertThat(map.size(), is(2));
+        assertThat(map.containsKey("key1"), is(true));
         assertEquals(map.get("key1"), "1");
-        assertFalse(map.containsKey("key2"));
-        assertTrue(map.containsKey("key3"));
+        assertThat(map.containsKey("key2"), is(false));
+        assertThat(map.containsKey("key3"), is(true));
         assertEquals(map.get("key3"), "-1");
     }
 
@@ -84,10 +85,10 @@ public class JsonLayoutTest {
         jsonLayout.addTimestamp("key2", false, 1, map);
         jsonLayout.addTimestamp("key3", true, -1, map);
 
-        assertTrue(map.size() == 2);
-        assertTrue(map.containsKey("key1"));
-        assertFalse(map.containsKey("key2"));
-        assertTrue(map.containsKey("key3"));
+        assertThat(map.size(), is(2));
+        assertThat(map.containsKey("key1"), is(true));
+        assertThat(map.containsKey("key2"), is(false));
+        assertThat(map.containsKey("key3"), is(true));
         assertEquals("-1", map.get("key3"));
     }
 
@@ -97,15 +98,15 @@ public class JsonLayoutTest {
         JsonLayout jsonLayout = new JsonLayout();
         jsonLayout.addRequestTime(10001, map);
 
-        assertTrue(map.size() == 1);
-        assertTrue(map.containsKey(REQUESTTIME_ATTR_NAME));
+        assertThat(map.size(), is(1));
+        assertThat(map.containsKey(REQUESTTIME_ATTR_NAME), is(true));
         assertEquals("10.001", map.get(REQUESTTIME_ATTR_NAME));
 
         Map<String, Object> map2 = new LinkedHashMap<String, Object>();
         JsonLayout jsonLayout2 = new JsonLayout();
         jsonLayout2.addRequestTime(-1, map2);
 
-        assertTrue(map2.size() == 0);
+        assertThat(map2.size(), is(0));
     }
 
     @Test
@@ -116,7 +117,7 @@ public class JsonLayoutTest {
         Map<String, String> mapWithData = new HashMap<String, String>();
         mapWithData.put("mapKey1", "mapValue1");
         Map<String, String[]> mapWithArrayValue = new HashMap<String, String[]>();
-        mapWithArrayValue.put("mapKey1", new String[]{"mapValue1","mapValue2","mapValue3"});
+        mapWithArrayValue.put("mapKey1", new String[]{"mapValue1", "mapValue2", "mapValue3"});
 
         JsonLayout jsonLayout = new JsonLayout();
         jsonLayout.addMap("key1", true, emptyMap, map);
@@ -124,11 +125,11 @@ public class JsonLayoutTest {
         jsonLayout.addMap("key3", true, mapWithArrayValue, map);
         jsonLayout.addMap("key4", false, mapWithArrayValue, map);
 
-        assertTrue(map.size() == 2);
-        assertFalse(map.containsKey("key1"));
+        assertThat(map.size(), is(2));
+        assertThat(map.containsKey("key1"), is(false));
         assertEquals(mapWithData, map.get("key2"));
         assertEquals(mapWithArrayValue, map.get("key3"));
-        assertFalse(map.containsKey("key4"));
+        assertThat(map.containsKey("key4"), is(false));
     }
 
 
@@ -146,19 +147,19 @@ public class JsonLayoutTest {
         jsonLayout.setContext(context);
         String log = jsonLayout.doLayout(iAccessEvent);
 
-        assertTrue(log.contains(String.format("%s=%s", JsonLayout.REMOTEHOST_ATTR_NAME, event.getRemoteHost())));
-        assertTrue(log.contains(String.format("%s=%s", JsonLayout.REMOTEUSER_ATTR_NAME, event.getRemoteUser())));
-        assertTrue(log.contains(String.format("%s=%s", JsonLayout.REMOTEADDR_ATTR_NAME, event.getRemoteAddr())));
-        assertTrue(log.contains(String.format("%s=%s", JsonLayout.METHOD_ATTR_NAME, event.getMethod())));
-        if(event.getRequestHeaderMap().size() == 2){
+        assertThat(log.contains(String.format("%s=%s", JsonLayout.REMOTEHOST_ATTR_NAME, event.getRemoteHost())), is(true));
+        assertThat(log.contains(String.format("%s=%s", JsonLayout.REMOTEUSER_ATTR_NAME, event.getRemoteUser())), is(true));
+        assertThat(log.contains(String.format("%s=%s", JsonLayout.REMOTEADDR_ATTR_NAME, event.getRemoteAddr())), is(true));
+        assertThat(log.contains(String.format("%s=%s", JsonLayout.METHOD_ATTR_NAME, event.getMethod())), is(true));
+        if (event.getRequestHeaderMap().size() == 2) {
             Iterator<Map.Entry<String, String>> iterator = event.getRequestHeaderMap().entrySet().iterator();
             Map.Entry<String, String> firstInMap = iterator.next();
             Map.Entry<String, String> secondInMap = iterator.next();
-            assertTrue(log.contains(String.format("%s={%s=%s, %s=%s}", JsonLayout.REQUESTHEADER_ATTR_NAME, firstInMap.getKey(), firstInMap.getValue(), secondInMap.getKey(), secondInMap.getValue())));
+            assertThat(log.contains(String.format("%s={%s=%s, %s=%s}", JsonLayout.REQUESTHEADER_ATTR_NAME, firstInMap.getKey(), firstInMap.getValue(), secondInMap.getKey(), secondInMap.getValue())), is(true));
         }
-        assertTrue(log.contains(String.format("%s=%s", JsonLayout.PROTOCOL_ATTR_NAME, event.getProtocol())));
-        assertTrue(log.contains(String.format("%s=%s", JsonLayout.SERVERNAME_ATTR_NAME, event.getServerName())));
-        assertTrue(log.contains(String.format("%s=%s", JsonLayout.STATUSCODE_ATTR_NAME, event.getStatusCode())));
+        assertThat(log.contains(String.format("%s=%s", JsonLayout.PROTOCOL_ATTR_NAME, event.getProtocol())), is(true));
+        assertThat(log.contains(String.format("%s=%s", JsonLayout.SERVERNAME_ATTR_NAME, event.getServerName())), is(true));
+        assertThat(log.contains(String.format("%s=%s", JsonLayout.STATUSCODE_ATTR_NAME, event.getStatusCode())), is(true));
     }
 
     @Test
@@ -180,10 +181,10 @@ public class JsonLayoutTest {
         jsonLayout.includeResponseContent = true;
         String log = jsonLayout.doLayout(iAccessEvent);
 
-        assertTrue(log.contains(String.format("%s=%s", JsonLayout.CONTENTLENGTH_ATTR_NAME, event.getContentLength())));
-        assertTrue(log.contains(String.format("%s=%s", JsonLayout.REQUESTURL_ATTR_NAME, event.getMethod())));
-        assertTrue(log.contains(String.format("%s=%s", JsonLayout.LOCALPORT_ATTR_NAME, event.getLocalPort())));
-        assertTrue(log.contains(String.format("%s=%s", JsonLayout.RESPONSECONTENT_ATTR_NAME, event.getResponseContent())));
-        assertTrue(log.contains(String.format("%s=%s", JsonLayout.REQUESTCONTENT_ATTR_NAME, event.getRequestContent())));
+        assertThat(log.contains(String.format("%s=%s", JsonLayout.CONTENTLENGTH_ATTR_NAME, event.getContentLength())), is(true));
+        assertThat(log.contains(String.format("%s=%s", JsonLayout.REQUESTURL_ATTR_NAME, event.getMethod())), is(true));
+        assertThat(log.contains(String.format("%s=%s", JsonLayout.LOCALPORT_ATTR_NAME, event.getLocalPort())), is(true));
+        assertThat(log.contains(String.format("%s=%s", JsonLayout.RESPONSECONTENT_ATTR_NAME, event.getResponseContent())), is(true));
+        assertThat(log.contains(String.format("%s=%s", JsonLayout.REQUESTCONTENT_ATTR_NAME, event.getRequestContent())), is(true));
     }
 }

--- a/json/classic/src/test/input/json/jsonLayout.xml
+++ b/json/classic/src/test/input/json/jsonLayout.xml
@@ -16,7 +16,7 @@
 
     <appender name="STR_LIST" class="ch.qos.logback.core.read.ListAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
-            <layout class="ch.qos.logback.contrib.json.access.JsonLayout">
+            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
                 <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter"/>
             </layout>
         </encoder>

--- a/json/classic/src/test/input/json/jsonLayout.xml
+++ b/json/classic/src/test/input/json/jsonLayout.xml
@@ -22,5 +22,7 @@
         </encoder>
     </appender>
 
-    <appender-ref ref="STR_LIST"/>
+    <root>
+        <appender-ref ref="STR_LIST"/>
+    </root>
 </configuration>

--- a/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
+++ b/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
@@ -20,6 +20,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.joran.spi.JoranException;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -100,12 +101,11 @@ public class JsonLayoutTest {
     @Test
     public void jsonLayout() throws Exception {
         configure("src/test/input/json/jsonLayout.xml");
-        String loggerName = "STR_LIST";
+        String loggerName = "ROOT";
         String message = "Info message";
         String debugMessage = "Debug message";
-        Logger logger = context.getLogger(loggerName);
+        Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         logger.info("Test");
-
         ILoggingEvent event = new LoggingEvent("my.class.name", logger, Level.INFO, message, null, null);
 
         JsonLayout jsonLayout = new JsonLayout();

--- a/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
+++ b/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
@@ -36,6 +36,7 @@ public class JsonLayoutTest {
     private LoggerContext context = new LoggerContext();
 
     private void configure(String file) throws JoranException {
+        context.reset();
         JoranConfigurator jc = new JoranConfigurator();
         jc.setContext(context);
         jc.doConfigure(file);

--- a/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
+++ b/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
@@ -140,7 +140,6 @@ public class JsonLayoutTest {
         try {
             long timestamp = Long.parseLong(timestampValue);
             new Date(timestamp);
-            assertTrue(true);
         } catch (NumberFormatException e) {
             fail(String.format("Value of attribute %s could not be converted to a valid Date", JsonLayout.TIMESTAMP_ATTR_NAME));
         }

--- a/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
+++ b/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.util.*;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
 /**
@@ -48,11 +49,11 @@ public class JsonLayoutTest {
         jsonLayout.add("key2", false, "value2", map);
         jsonLayout.add("key3", true, null, map);
 
-        assertTrue(map.size() == 1);
-        assertTrue(map.containsKey("key1"));
+        assertThat(map.size(), is(1));
+        assertThat(map.containsKey("key1"), is(true));
         assertEquals(map.get("key1"), "value1");
-        assertFalse(map.containsKey("key2"));
-        assertFalse(map.containsKey("key3"));
+        assertThat(map.containsKey("key2"), is(false));
+        assertThat(map.containsKey("key3"), is(false));
     }
 
     @Test
@@ -64,10 +65,10 @@ public class JsonLayoutTest {
         jsonLayout.addTimestamp("key2", false, 1, map);
         jsonLayout.addTimestamp("key3", true, -1, map);
 
-        assertTrue(map.size() == 2);
-        assertTrue(map.containsKey("key1"));
-        assertFalse(map.containsKey("key2"));
-        assertTrue(map.containsKey("key3"));
+        assertThat(map.size(), is(2));
+        assertThat(map.containsKey("key1"), is(true));
+        assertThat(map.containsKey("key2"), is(false));
+        assertThat(map.containsKey("key3"), is(true));
         assertEquals("-1", map.get("key3"));
     }
 
@@ -87,11 +88,11 @@ public class JsonLayoutTest {
         jsonLayout.addMap("key3", true, mapWithArrayValue, map);
         jsonLayout.addMap("key4", false, mapWithArrayValue, map);
 
-        assertTrue(map.size() == 2);
-        assertFalse(map.containsKey("key1"));
+        assertThat(map.size(), is(2));
+        assertThat(map.containsKey("key1"), is(false));
         assertEquals(mapWithData, map.get("key2"));
         assertEquals(mapWithArrayValue, map.get("key3"));
-        assertFalse(map.containsKey("key4"));
+        assertThat(map.containsKey("key4"), is(false));
     }
 
     @Test
@@ -110,10 +111,10 @@ public class JsonLayoutTest {
         String log = jsonLayout.doLayout(event);
 
         assertTimestamp(log);
-        assertTrue(log.contains(String.format("%s=%s", JsonLayout.LEVEL_ATTR_NAME, Level.INFO)));
-        assertTrue(log.contains(String.format("%s=%s", JsonLayout.THREAD_ATTR_NAME, "main")));
-        assertTrue(log.contains(String.format("%s=%s", JsonLayout.LOGGER_ATTR_NAME, loggerName)));
-        assertTrue(log.contains(String.format("%s=%s", JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, message)));
+        assertThat(log.contains(String.format("%s=%s", JsonLayout.LEVEL_ATTR_NAME, Level.INFO)), is(true));
+        assertThat(log.contains(String.format("%s=%s", JsonLayout.THREAD_ATTR_NAME, "main")), is(true));
+        assertThat(log.contains(String.format("%s=%s", JsonLayout.LOGGER_ATTR_NAME, loggerName)), is(true));
+        assertThat(log.contains(String.format("%s=%s", JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, message)), is(true));
 
         jsonLayout.setIncludeContextName(true);
         jsonLayout.setIncludeMDC(true);
@@ -126,11 +127,11 @@ public class JsonLayoutTest {
         String logWithException = jsonLayout.doLayout(eventWithException);
 
         assertTimestamp(logWithException);
-        assertTrue(logWithException.contains(String.format("%s=%s", JsonLayout.LEVEL_ATTR_NAME, Level.DEBUG)));
-        assertTrue(logWithException.contains(String.format("%s=%s", JsonLayout.LOGGER_ATTR_NAME, loggerName)));
-        assertTrue(logWithException.contains(String.format("%s=%s", JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, debugMessage)));
-        assertTrue(logWithException.contains(String.format("%s=%s", JsonLayout.MESSAGE_ATTR_NAME, debugMessage)));
-        assertTrue(logWithException.contains(String.format("%s=%s", JsonLayout.EXCEPTION_ATTR_NAME, exception.toString())));
+        assertThat(logWithException.contains(String.format("%s=%s", JsonLayout.LEVEL_ATTR_NAME, Level.DEBUG)), is(true));
+        assertThat(logWithException.contains(String.format("%s=%s", JsonLayout.LOGGER_ATTR_NAME, loggerName)), is(true));
+        assertThat(logWithException.contains(String.format("%s=%s", JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, debugMessage)), is(true));
+        assertThat(logWithException.contains(String.format("%s=%s", JsonLayout.MESSAGE_ATTR_NAME, debugMessage)), is(true));
+        assertThat(logWithException.contains(String.format("%s=%s", JsonLayout.EXCEPTION_ATTR_NAME, exception.toString())), is(true));
     }
 
     private void assertTimestamp(String log) {

--- a/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
+++ b/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (C) 2016, The logback-contrib developers. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.contrib.json.classic;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.joran.spi.JoranException;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests the {@link JsonLayout} class
+ *
+ * @author Espen A. Fossen
+ */
+public class JsonLayoutTest {
+
+    private LoggerContext context = new LoggerContext();
+
+    private void configure(String file) throws JoranException {
+        JoranConfigurator jc = new JoranConfigurator();
+        jc.setContext(context);
+        jc.doConfigure(file);
+    }
+
+    @Test
+    public void addToJsonMap() throws Exception {
+        Map<String, Object> map = new LinkedHashMap<String, Object>();
+        JsonLayout jsonLayout = new JsonLayout();
+        jsonLayout.add("key1", true, "value1", map);
+        jsonLayout.add("key2", false, "value2", map);
+        jsonLayout.add("key3", true, null, map);
+
+        assertTrue(map.size() == 1);
+        assertTrue(map.containsKey("key1"));
+        assertEquals(map.get("key1"), "value1");
+        assertFalse(map.containsKey("key2"));
+        assertFalse(map.containsKey("key3"));
+    }
+
+    @Test
+    public void addTimestampToJsonMap() throws Exception {
+        Map<String, Object> map = new LinkedHashMap<String, Object>();
+        JsonLayout jsonLayout = new JsonLayout();
+        jsonLayout.setTimestampFormat("yyyy-MM-dd HH:mm:ss.SSS");
+        jsonLayout.addTimestamp("key1", true, 1, map);
+        jsonLayout.addTimestamp("key2", false, 1, map);
+        jsonLayout.addTimestamp("key3", true, -1, map);
+
+        assertTrue(map.size() == 2);
+        assertTrue(map.containsKey("key1"));
+        assertFalse(map.containsKey("key2"));
+        assertTrue(map.containsKey("key3"));
+        assertEquals("-1", map.get("key3"));
+    }
+
+    @Test
+    public void addMapToJsonMap() throws Exception {
+        Map<String, Object> map = new LinkedHashMap<String, Object>();
+
+        Map<String, String> emptyMap = new HashMap<String, String>();
+        Map<String, String> mapWithData = new HashMap<String, String>();
+        mapWithData.put("mapKey1", "mapValue1");
+        Map<String, String[]> mapWithArrayValue = new HashMap<String, String[]>();
+        mapWithArrayValue.put("mapKey1", new String[]{"mapValue1","mapValue2","mapValue3"});
+
+        JsonLayout jsonLayout = new JsonLayout();
+        jsonLayout.addMap("key1", true, emptyMap, map);
+        jsonLayout.addMap("key2", true, mapWithData, map);
+        jsonLayout.addMap("key3", true, mapWithArrayValue, map);
+        jsonLayout.addMap("key4", false, mapWithArrayValue, map);
+
+        assertTrue(map.size() == 2);
+        assertFalse(map.containsKey("key1"));
+        assertEquals(mapWithData, map.get("key2"));
+        assertEquals(mapWithArrayValue, map.get("key3"));
+        assertFalse(map.containsKey("key4"));
+    }
+
+    @Test
+    public void jsonLayout() throws Exception {
+        configure("src/test/input/json/jsonLayout.xml");
+        String loggerName = "STR_LIST";
+        String message = "Info message";
+        String debugMessage = "Debug message";
+        Logger logger = context.getLogger(loggerName);
+        logger.info("Test");
+
+        ILoggingEvent event = new LoggingEvent("my.class.name", logger, Level.INFO, message, null, null);
+
+        JsonLayout jsonLayout = new JsonLayout();
+        jsonLayout.setContext(context);
+        String log = jsonLayout.doLayout(event);
+
+        assertTimestamp(log);
+        assertTrue(log.contains(String.format("%s=%s", JsonLayout.LEVEL_ATTR_NAME, Level.INFO)));
+        assertTrue(log.contains(String.format("%s=%s", JsonLayout.THREAD_ATTR_NAME, "main")));
+        assertTrue(log.contains(String.format("%s=%s", JsonLayout.LOGGER_ATTR_NAME, loggerName)));
+        assertTrue(log.contains(String.format("%s=%s", JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, message)));
+
+        jsonLayout.setIncludeContextName(true);
+        jsonLayout.setIncludeMDC(true);
+        jsonLayout.setIncludeLoggerName(true);
+        jsonLayout.setIncludeException(true);
+        jsonLayout.setIncludeMessage(true);
+
+        RuntimeException exception = new RuntimeException("Exception");
+        ILoggingEvent eventWithException = new LoggingEvent("my.class.name", logger, Level.DEBUG, debugMessage, exception, null);
+        String logWithException = jsonLayout.doLayout(eventWithException);
+
+        assertTimestamp(logWithException);
+        assertTrue(logWithException.contains(String.format("%s=%s", JsonLayout.LEVEL_ATTR_NAME, Level.DEBUG)));
+        assertTrue(logWithException.contains(String.format("%s=%s", JsonLayout.LOGGER_ATTR_NAME, loggerName)));
+        assertTrue(logWithException.contains(String.format("%s=%s", JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, debugMessage)));
+        assertTrue(logWithException.contains(String.format("%s=%s", JsonLayout.MESSAGE_ATTR_NAME, debugMessage)));
+        assertTrue(logWithException.contains(String.format("%s=%s", JsonLayout.EXCEPTION_ATTR_NAME, exception.toString())));
+    }
+
+    private void assertTimestamp(String log) {
+        int timestampStart = log.indexOf(JsonLayout.TIMESTAMP_ATTR_NAME) + JsonLayout.TIMESTAMP_ATTR_NAME.length() + 1;
+        int timestampEnd = log.indexOf(",", timestampStart);
+        String timestampValue = log.substring(timestampStart, timestampEnd);
+        try {
+            long timestamp = Long.parseLong(timestampValue);
+            new Date(timestamp);
+            assertTrue(true);
+        } catch (NumberFormatException e) {
+            fail(String.format("Value of attribute %s could not be converted to a valid Date", JsonLayout.TIMESTAMP_ATTR_NAME));
+        }
+    }
+
+}

--- a/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
+++ b/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
@@ -138,6 +138,10 @@ public class JsonLayoutTest {
 
     private void assertTimestamp(String log) {
         int timestampStart = log.indexOf(JsonLayout.TIMESTAMP_ATTR_NAME) + JsonLayout.TIMESTAMP_ATTR_NAME.length() + 1;
+        if(timestampStart == -1){
+            fail(String.format("No instance of %s found in log, there should be one.", JsonLayout.TIMESTAMP_ATTR_NAME));
+        }
+
         int timestampEnd = log.indexOf(",", timestampStart);
         String timestampValue = log.substring(timestampStart, timestampEnd);
         try {

--- a/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
+++ b/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
@@ -137,16 +137,16 @@ public class JsonLayoutTest {
     }
 
     private void assertTimestamp(String log) {
-        int timestampStart = log.indexOf(JsonLayout.TIMESTAMP_ATTR_NAME) + JsonLayout.TIMESTAMP_ATTR_NAME.length() + 1;
-        if(timestampStart == -1){
+        int timestamp = log.indexOf(JsonLayout.TIMESTAMP_ATTR_NAME);
+        if(timestamp == -1){
             fail(String.format("No instance of %s found in log, there should be one.", JsonLayout.TIMESTAMP_ATTR_NAME));
         }
 
+        int timestampStart = timestamp + JsonLayout.TIMESTAMP_ATTR_NAME.length() + 1;
         int timestampEnd = log.indexOf(",", timestampStart);
         String timestampValue = log.substring(timestampStart, timestampEnd);
         try {
-            long timestamp = Long.parseLong(timestampValue);
-            new Date(timestamp);
+            new Date(Long.parseLong(timestampValue));
         } catch (NumberFormatException e) {
             fail(String.format("Value of attribute %s could not be converted to a valid Date", JsonLayout.TIMESTAMP_ATTR_NAME));
         }

--- a/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
+++ b/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
@@ -24,6 +24,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 import static org.junit.matchers.JUnitMatchers.containsString;
@@ -53,10 +55,10 @@ public class JsonLayoutTest {
         jsonLayout.add("key3", true, null, map);
 
         assertThat(map.size(), is(1));
-        assertThat(map.containsKey("key1"), is(true));
+        assertThat(map, hasKey("key1"));
         assertEquals(map.get("key1"), "value1");
-        assertThat(map.containsKey("key2"), is(false));
-        assertThat(map.containsKey("key3"), is(false));
+        assertThat(map, not(hasKey("key2")));
+        assertThat(map, not(hasKey("key3")));
     }
 
     @Test
@@ -69,9 +71,9 @@ public class JsonLayoutTest {
         jsonLayout.addTimestamp("key3", true, -1, map);
 
         assertThat(map.size(), is(2));
-        assertThat(map.containsKey("key1"), is(true));
-        assertThat(map.containsKey("key2"), is(false));
-        assertThat(map.containsKey("key3"), is(true));
+        assertThat(map, hasKey("key1"));
+        assertThat(map, not(hasKey("key2")));
+        assertThat(map, hasKey("key3"));
         assertEquals("-1", map.get("key3"));
     }
 
@@ -92,10 +94,10 @@ public class JsonLayoutTest {
         jsonLayout.addMap("key4", false, mapWithArrayValue, map);
 
         assertThat(map.size(), is(2));
-        assertThat(map.containsKey("key1"), is(false));
+        assertThat(map, not(hasKey("key1")));
         assertEquals(mapWithData, map.get("key2"));
         assertEquals(mapWithArrayValue, map.get("key3"));
-        assertThat(map.containsKey("key4"), is(false));
+        assertThat(map, not(hasKey("key4")));
     }
 
     @Test

--- a/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
+++ b/json/classic/src/test/java/ch/qos/logback/contrib/json/classic/JsonLayoutTest.java
@@ -25,6 +25,7 @@ import java.util.*;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
+import static org.junit.matchers.JUnitMatchers.containsString;
 
 /**
  * Tests the {@link JsonLayout} class
@@ -112,10 +113,10 @@ public class JsonLayoutTest {
         String log = jsonLayout.doLayout(event);
 
         assertTimestamp(log);
-        assertThat(log.contains(String.format("%s=%s", JsonLayout.LEVEL_ATTR_NAME, Level.INFO)), is(true));
-        assertThat(log.contains(String.format("%s=%s", JsonLayout.THREAD_ATTR_NAME, "main")), is(true));
-        assertThat(log.contains(String.format("%s=%s", JsonLayout.LOGGER_ATTR_NAME, loggerName)), is(true));
-        assertThat(log.contains(String.format("%s=%s", JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, message)), is(true));
+        assertThat(log, containsString(String.format("%s=%s", JsonLayout.LEVEL_ATTR_NAME, Level.INFO)));
+        assertThat(log, containsString(String.format("%s=%s", JsonLayout.THREAD_ATTR_NAME, "main")));
+        assertThat(log, containsString(String.format("%s=%s", JsonLayout.LOGGER_ATTR_NAME, loggerName)));
+        assertThat(log, containsString(String.format("%s=%s", JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, message)));
 
         jsonLayout.setIncludeContextName(true);
         jsonLayout.setIncludeMDC(true);
@@ -128,11 +129,11 @@ public class JsonLayoutTest {
         String logWithException = jsonLayout.doLayout(eventWithException);
 
         assertTimestamp(logWithException);
-        assertThat(logWithException.contains(String.format("%s=%s", JsonLayout.LEVEL_ATTR_NAME, Level.DEBUG)), is(true));
-        assertThat(logWithException.contains(String.format("%s=%s", JsonLayout.LOGGER_ATTR_NAME, loggerName)), is(true));
-        assertThat(logWithException.contains(String.format("%s=%s", JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, debugMessage)), is(true));
-        assertThat(logWithException.contains(String.format("%s=%s", JsonLayout.MESSAGE_ATTR_NAME, debugMessage)), is(true));
-        assertThat(logWithException.contains(String.format("%s=%s", JsonLayout.EXCEPTION_ATTR_NAME, exception.toString())), is(true));
+        assertThat(logWithException, containsString(String.format("%s=%s", JsonLayout.LEVEL_ATTR_NAME, Level.DEBUG)));
+        assertThat(logWithException, containsString(String.format("%s=%s", JsonLayout.LOGGER_ATTR_NAME, loggerName)));
+        assertThat(logWithException, containsString(String.format("%s=%s", JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, debugMessage)));
+        assertThat(logWithException, containsString(String.format("%s=%s", JsonLayout.MESSAGE_ATTR_NAME, debugMessage)));
+        assertThat(logWithException, containsString(String.format("%s=%s", JsonLayout.EXCEPTION_ATTR_NAME, exception.toString())));
     }
 
     private void assertTimestamp(String log) {

--- a/json/core/src/main/java/ch/qos/logback/contrib/json/JsonLayoutBase.java
+++ b/json/core/src/main/java/ch/qos/logback/contrib/json/JsonLayoutBase.java
@@ -24,6 +24,7 @@ import java.util.TimeZone;
 /**
  * @author Les Hazlewood
  * @author Pierre Queinnec
+ * @author Espen A. Fossen
  * @since 0.1
  */
 public abstract class JsonLayoutBase<E> extends LayoutBase<E> {
@@ -80,6 +81,27 @@ public abstract class JsonLayoutBase<E> extends LayoutBase<E> {
         }
 
         return format(date, format);
+    }
+
+    public void addMap(String key, boolean field, Map<String, ?> mapValue, Map<String, Object> map) {
+        if (field && mapValue != null && !mapValue.isEmpty()) {
+            map.put(key, mapValue);
+        }
+    }
+
+    public void addTimestamp(String key, boolean field, long timeStamp, Map<String, Object> map) {
+        if(field){
+            String formatted = formatTimestamp(timeStamp);
+            if (formatted != null) {
+                map.put(key, formatted);
+            }
+        }
+    }
+
+    public void add(String fieldName, boolean field, String value, Map<String, Object> map) {
+        if (field && value != null) {
+            map.put(fieldName, value);
+        }
     }
 
     protected DateFormat createDateFormat(String timestampFormat) {

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
         <mockito.version>2.0.44-beta</mockito.version>
         <groovy.version>1.8.6</groovy.version>
         <junit.version>4.8.2</junit.version>
+        <hamcrest.version>2.0.0.0</hamcrest.version>
 
     </properties>
 
@@ -132,7 +133,12 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-junit</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>


### PR DESCRIPTION
After refactoring ch.qos.logback.contrib.json.access.JsonLayout as part of #10 it seemed appropriate to also refactor ch.qos.logback.contrib.json.classic.JsonLayout. This PR does the following.

- Move all common code from JsonLayout in classic/access to JsonLayoutBase in logback-json-core
- Refactore ch.qos.logback.contrib.json.classic.JsonLayout.toJsonMap() method to reduce complexity
- Add junit tests for ch.qos.logback.contrib.json.classic.JsonLayout