### PR TITLE
Correct fragment host

### DIFF
--- a/janino-fragment/src/main/resources/META-INF/MANIFEST.MF
+++ b/janino-fragment/src/main/resources/META-INF/MANIFEST.MF
@@ -1,2 +1,2 @@
-Fragment-Host: org.codehaus.janino
+Fragment-Host: org.codehaus.janino.janino
 Require-Bundle: ch.qos.logback.core


### PR DESCRIPTION
The janino jar has ``Bundle-SymbolicName: org.codehaus.janino.janino``