### PR TITLE
Add End Of Line to each event

### DIFF
--- a/jackson/src/main/java/ch/qos/logback/contrib/jackson/JacksonJsonFormatter.java
+++ b/jackson/src/main/java/ch/qos/logback/contrib/jackson/JacksonJsonFormatter.java
@@ -33,10 +33,12 @@ public class JacksonJsonFormatter implements JsonFormatter {
 
     private ObjectMapper objectMapper;
     private boolean prettyPrint;
+    private boolean eventEol;
 
     public JacksonJsonFormatter() {
         this.objectMapper = new ObjectMapper();
         this.prettyPrint = false;
+        this.eventEol = false;
     }
 
     @Override
@@ -52,7 +54,7 @@ public class JacksonJsonFormatter implements JsonFormatter {
 
         writer.flush();
 
-        return writer.toString();
+        return writer.toString() + (eventEol ? "\n": "");
     }
 
     public ObjectMapper getObjectMapper() {
@@ -69,6 +71,10 @@ public class JacksonJsonFormatter implements JsonFormatter {
 
     public void setPrettyPrint(boolean prettyPrint) {
         this.prettyPrint = prettyPrint;
+    }
+
+    public void setEventEol(boolean eventEol) {
+        this.eventEol = eventEol;
     }
 }
 


### PR DESCRIPTION
In order to create log files as [ndjson](http://ndjson.org/), so each line is a complete json, I've added the parameter "eventEol" (same name than [log4j layout](https://logging.apache.org/log4j/2.0/manual/layouts.html#JSONLayout) has) to add a new line character (\n) after each event.

This allow an easier way to manage them with tools like filebeat.