### PR TITLE
replace Require-Bundle with DynamicImport-Package

### DIFF
--- a/janino-fragment/src/main/resources/META-INF/MANIFEST.MF
+++ b/janino-fragment/src/main/resources/META-INF/MANIFEST.MF
@@ -1,2 +1,3 @@
 Fragment-Host: org.codehaus.janino
-Require-Bundle: ch.qos.logback.core
+DynamicImport-Package: ch.qos.logback.*,\
+org.slf4j


### PR DESCRIPTION
This fixes an class-loading issue in OSGI environments reported in #28 and #22 