### PR TITLE
Upgrade dependencies to remove vulnerabilities

### DIFF
--- a/mongodb/access/src/test/java/ch/qos/logback/contrib/mongodb/MongoDBAccessEventAppenderTest.java
+++ b/mongodb/access/src/test/java/ch/qos/logback/contrib/mongodb/MongoDBAccessEventAppenderTest.java
@@ -18,7 +18,7 @@ import java.util.Date;
 
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/mongodb/core/src/test/java/ch/qos/logback/contrib/mongodb/MongoDBAppenderBaseTest.java
+++ b/mongodb/core/src/test/java/ch/qos/logback/contrib/mongodb/MongoDBAppenderBaseTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertTrue;
 import com.mongodb.*;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/pom.xml
+++ b/pom.xml
@@ -106,15 +106,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Compile Dependencies: -->
-        <logback.version>1.1.8</logback.version>
-        <jackson.version>2.8.5</jackson.version>
+        <logback.version>1.2.10</logback.version>
+        <jackson.version>2.13.1</jackson.version>
         <mongo-java-driver.version>2.10.1</mongo-java-driver.version>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
 
         <!-- Test Dependencies: -->
-        <mockito.version>2.0.44-beta</mockito.version>
+        <mockito.version>4.3.1</mockito.version>
         <groovy.version>1.8.6</groovy.version>
-        <junit.version>4.8.2</junit.version>
+        <junit.version>4.13.2</junit.version>
         <hamcrest.version>2.0.0.0</hamcrest.version>
 
     </properties>
@@ -306,6 +306,21 @@
                     <includes>
                         <include>**/*.java</include>
                     </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>6.5.3</version>
+                <configuration>
+                    <skipTestScope>false</skipTestScope>
                 </configuration>
                 <executions>
                     <execution>

--- a/xmpp/src/test/java/ch/qos/logback/classic/net/XmppAppenderTest.java
+++ b/xmpp/src/test/java/ch/qos/logback/classic/net/XmppAppenderTest.java
@@ -26,10 +26,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
# Changes
- Added OWASP plugin, but without failing on vulnerability found
- Upgraded logback to 1.2.10
- Upgraded jackson to 2.13.5
- Upgraded mockito to 4.3.1
- Upgraded JUnit to 4.13.2

# Decisions
I could not turn on failBuildOnCVSS because there are some dependencies on eclipse and xmpp subpackages that do not have newer versions without vulnerabilities. In case this is merged, I'll go update those dependencies as well.