### PR TITLE
Default line separation to `true`

### DIFF
--- a/json/core/src/main/java/ch/qos/logback/contrib/json/JsonLayoutBase.java
+++ b/json/core/src/main/java/ch/qos/logback/contrib/json/JsonLayoutBase.java
@@ -40,7 +40,7 @@ public abstract class JsonLayoutBase<E> extends LayoutBase<E> {
 
     public JsonLayoutBase() {
         this.includeTimestamp = true;
-        this.appendLineSeparator = false;
+        this.appendLineSeparator = true;
     }
 
     @Override


### PR DESCRIPTION
When ingesting logs via DataDog the logs are malformed if `appendLineSeparator` is `false`.

### `appendLineSeparator = false`
We get log lines of concatenated JSON objects, which aren't parsed correctly. Long lines are snipped somewhere due to log streaming. For example
```
{"name": "john","age":11}{"otherEvent": ["foo"]}
{"name": "jane","age":22}{"otherEvent": ["bar"]}
```


### `appendLineSeparator = true`
A single JSON object per line, easy to parse, no snipping. For example:
```
{"name": "john","age":11}
{"otherEvent": ["foo"]}
{"name": "jane","age":22}
{"otherEvent": ["bar"]}
```

